### PR TITLE
Add `DigitalRgb` component

### DIFF
--- a/src/lib/johnny-five/digital-rgb.ts
+++ b/src/lib/johnny-five/digital-rgb.ts
@@ -1,0 +1,68 @@
+import type {
+    Board,
+    LedOption,
+} from 'johnny-five';
+
+import {
+    Led,
+} from 'johnny-five';
+
+const colors = [
+    'blue',
+    'green',
+    'red',
+] as const;
+
+export interface DigitalRgbOptions {
+    anode?: boolean | undefined;
+    board?: Board | undefined;
+    pins: {
+        blue: LedOption['pin'];
+        green: LedOption['pin'];
+        red: LedOption['pin'];
+    }
+}
+
+type Leds = Record<typeof colors[number], Led>;
+
+export default class DigitalRgb {
+    leds: Leds;
+
+    constructor(options: DigitalRgbOptions) {
+        const baseOptions: Partial<LedOption> = {
+            board: options.board,
+            isAnode: options.anode,
+        };
+
+        this.leds = colors.reduce((leds, color) => {
+            leds[color] = new Led({
+                ...baseOptions,
+                pin: options.pins[color],
+            });
+
+            return leds;
+        }, {} as Partial<Leds>) as Leds;
+    }
+
+    green() {
+        this.off();
+        this.leds.green.on();
+    }
+
+    off() {
+        this.leds.blue.off();
+        this.leds.green.off();
+        this.leds.red.off();
+    }
+
+    red() {
+        this.off();
+        this.leds.red.on();
+    }
+
+    white() {
+        this.leds.blue.on();
+        this.leds.green.on();
+        this.leds.red.on();
+    }
+}

--- a/src/lib/model/jury-member/rgb-led.ts
+++ b/src/lib/model/jury-member/rgb-led.ts
@@ -1,37 +1,37 @@
 import type JuryMember from 'lib/model/jury-member';
 import type {
-    Board,
-} from 'johnny-five';
+    DigitalRgbOptions,
+} from 'lib/johnny-five/digital-rgb';
 
-import {
-    Led,
-} from 'johnny-five';
+import DigitalRgb from 'lib/johnny-five/digital-rgb';
 
 export interface JuryRefereeLedsOptions {
-    anode?: Led.RGBOption['isAnode'];
-    board?: Board;
-    pins: Led.RGBOption['pins'];
+    anode?: DigitalRgbOptions['anode'];
+    board?: DigitalRgbOptions['board'];
+    pins: DigitalRgbOptions['pins'];
 }
 
 export default (options: JuryRefereeLedsOptions) => {
-    const led = new Led.RGB({
+    const led = new DigitalRgb({
+        anode: options.anode,
         board: options.board,
         pins: options.pins,
-        isAnode: options.anode,
     });
 
     return (juryMember: JuryMember) => {
         juryMember.on('decision', () => {
-            led.color('#00ff00')
-            led.on();
+            console.log('decision', juryMember.number);
+            led.green();
         });
 
         juryMember.on('reset', () => {
+            console.log('reset', juryMember.number);
             led.off();
         });
 
         juryMember.on('reveal', ({ decision }) => {
-            led.color(decision === 'good' ? '#ffffff' : '#ff0000');
+            console.log('reveal', decision, juryMember.number);
+            led[decision === 'good' ? 'white' : 'red']();
         });
     };
 }

--- a/src/lib/model/jury/referee-rgb-leds.ts
+++ b/src/lib/model/jury/referee-rgb-leds.ts
@@ -1,24 +1,22 @@
 import type Jury from 'lib/model/jury';
 import type {
+    DigitalRgbOptions,
+} from 'lib/johnny-five/digital-rgb';
+import type {
     RefereeNumber,
 } from 'lib/model/referee';
-import type {
-    Board,
-} from 'johnny-five';
 
+import DigitalRgb from 'lib/johnny-five/digital-rgb';
 import {
     referees,
 } from 'lib/model/referee';
-import {
-    Led,
-} from 'johnny-five';
 
 export interface JuryRefereeRgbLedsOptions {
-    anode?: Led.RGBOption['isAnode'];
-    board?: Board;
-    referee1Pins: Led.RGBOption['pins'];
-    referee2Pins: Led.RGBOption['pins'];
-    referee3Pins: Led.RGBOption['pins'];
+    anode?: DigitalRgbOptions['anode'];
+    board?: DigitalRgbOptions['board'];
+    referee1Pins: DigitalRgbOptions['pins'];
+    referee2Pins: DigitalRgbOptions['pins'];
+    referee3Pins: DigitalRgbOptions['pins'];
 }
 
 type RefereePinsProperty = keyof Omit<JuryRefereeRgbLedsOptions, 'anode' | 'board'>;
@@ -30,20 +28,19 @@ export default (options: JuryRefereeRgbLedsOptions) => {
 
     const leds = referees.reduce((_leds, referee) => {
         const pinsProperty = refereePinsProperty(referee);
-        _leds[pinsProperty] = new Led.RGB({
+        _leds[pinsProperty] = new DigitalRgb({
+            anode: options.anode,
             board: options.board,
-            isAnode: options.anode,
             pins: options[pinsProperty],
         });
 
         return _leds;
-    }, {} as Record<RefereePinsProperty, Led.RGB>)
+    }, {} as Record<RefereePinsProperty, DigitalRgb>)
 
     return (jury: Jury) => {
         jury.on('refereeDecision', ({ decision, referee }) => {
             const ledProperty = refereePinsProperty(referee);
-            leds[ledProperty].color(decision === 'good' ? '#ffffff' : '#ff0000');
-            leds[ledProperty].on();
+            leds[ledProperty][decision === 'good' ? 'white' : 'red']();
         });
 
         jury.on('resetRefereeDecisions', () => {


### PR DESCRIPTION
Johnny-Five doesn't support RGB LEDs on non-PWM pins since almost all colors require `analogWrite()`. However, we only care about colors that can be achieved with digital writes (green, red, and white). This adds a new component that explicitly provides support for those three colors using any digital pins.